### PR TITLE
Seperate OpenAPI specs for eth1 and eth2 modes

### DIFF
--- a/.openapidoc/README.md
+++ b/.openapidoc/README.md
@@ -6,18 +6,19 @@ See `publishOpenApiSpec` job in `.circleci/config.yml`.
 
 ## Prerequisite 
 The script assumes that the `gradle build` (from the root directory) has already been executed which prepares the 
-Web3Signer spec at `core/build/resources/main/openapi/web3signer.yaml` (refered as `spec` in this document). 
+Web3Signer specs at `core/build/resources/main/openapi/web3signer-<mode>.yaml` (refered as `specs` in this document).
+Mode is eth2 and eth1. 
 
 ## Procedure
 The script performs following tasks:
 
 * Create `dist` directory (this folder will be pushed to `gh-pages` branch)
 * Read spec's version i.e. `info.version`.
-* Copy the spec to `dist` as `web3signer-latest.yaml`.
+* Copy the spec to `dist` as `web3signer-<mode>-latest.yaml`.
 
 For release version, it performs following additional steps (the release version do not have `-dev-` in it)
 
-* Copy the spec to `dist` as `web3signer-<version>.yaml`
+* Copy the spec to `dist` as `web3signer-<mode>-<version>.yaml`
 * Fetch `https://github.com/PegaSysEng/web3signer/raw/gh-pages/versions.json`
 * Update versions' json with release versions by updating `stable.spec` and `stable.source` to the release version and adding a new entry 
 for it. For example after adding spec version `0.0.2`, the `versions.json` would look like:
@@ -53,7 +54,6 @@ Following environment variables can be used to override defaults
 * `OA_GIT_EMAIL`          (default: `ci-build@consensys.net`)
 
 Following should only be overridden if changing the project
-* `OA_SPEC_PATH`          (default: `../core/build/resources/main/openapi/web3signer.yaml`)
 * `OA_VERSIONS_FILE_NAME` (default: `versions.json`)
 * `OA_DIST_DIR`           (default: `./dist`)
 * 

--- a/.openapidoc/README.md
+++ b/.openapidoc/README.md
@@ -14,7 +14,7 @@ The script performs following tasks:
 
 * Create `dist` directory (this folder will be pushed to `gh-pages` branch)
 * Read spec's version i.e. `info.version`.
-* Copy the spec to `dist` as `web3signer-<mode>-latest.yaml`.
+* Copy the specs to `dist` as `web3signer-<mode>-latest.yaml`.
 
 For release version, it performs following additional steps (the release version do not have `-dev-` in it)
 
@@ -56,5 +56,5 @@ Following environment variables can be used to override defaults
 Following should only be overridden if changing the project
 * `OA_VERSIONS_FILE_NAME` (default: `versions.json`)
 * `OA_DIST_DIR`           (default: `./dist`)
-* 
+* `OA_SPEC_DIR`          (default: `../core/build/resources/main/openapi`)
  

--- a/.openapidoc/config.js
+++ b/.openapidoc/config.js
@@ -1,0 +1,93 @@
+const fs = require("fs");
+const path = require("path");
+const yaml = require("js-yaml");
+const GitUrlParse = require("git-url-parse");
+
+const distDir = process.env.OA_DIST_DIR || "./dist";
+const specDir =
+  process.env.OA_SPEC_DIR || "../core/build/resources/main/openapi";
+const gitUrl =
+  process.env.OA_GIT_URL || "git@github.com:PegaSysEng/web3signer.git";
+const gitUserName = process.env.OA_GIT_USERNAME || "CircleCI Build";
+const gitEmail = process.env.OA_GIT_EMAIL || "ci-build@consensys.net";
+const branch = process.env.OA_GH_PAGES_BRANCH || "gh-pages";
+const versionsFileName = process.env.OA_VERSIONS_FILE_NAME || "versions.json";
+
+module.exports = {
+  getConfig,
+};
+
+function getConfig() {
+  const repo = GitUrlParse(gitUrl);
+  const specs = calculateSpecs();
+  if (specs.length == 0) {
+    throw new Error("Unable to parse specs in dist" + distDir);
+  }
+
+  return {
+    specs: specs,
+    distDir: distDir,
+    versions: calculateVersionDetails(repo, branch),
+    ghPagesConfig: {
+      add: true, // allows gh-pages module to keep remote files
+      branch: branch,
+      repo: repo.href,
+      user: {
+        name: gitUserName,
+        email: gitEmail,
+      },
+      message: `[skip ci] OpenAPI Publish [${specs[0].version}]`,
+    },
+  };
+}
+
+function calculateSpecs() {
+  const extension = ".yaml";
+  const specFiles = fs.readdirSync(specDir);
+  var specArr = [];
+  specFiles.forEach((file) => {
+    if (path.extname(file).toLowerCase() === extension) {
+      specArr.push(calculateSpecDetails(path.join(specDir, file)));
+    }
+  });
+  return specArr;
+}
+
+function calculateSpecDetails(specFile) {
+  const specVersion = calculateSpecVersion(specFile);
+  const release = isReleaseVersion(specVersion);
+  const latestDist = destinationPath(specFile, "latest");
+  const releaseDist = destinationPath(specFile, specVersion);
+
+  return {
+    path: specFile,
+    version: specVersion,
+    isReleaseVersion: release,
+    latestDist: latestDist,
+    releaseDist: releaseDist,
+  };
+}
+
+function calculateSpecVersion(specFile) {
+  return yaml.safeLoad(fs.readFileSync(specFile, "utf8")).info.version;
+}
+
+function isReleaseVersion(specVersion) {
+  // our main project's gradle's build calculateVersion puts -dev- for snapshot version
+  return !specVersion.includes("-dev-");
+}
+
+function destinationPath(specFile, suffix) {
+  const prefix = path.parse(specFile).name;
+  const extension = path.extname(specFile);
+  return path.join(distDir, `${prefix}-${suffix}${extension}`);
+}
+
+function calculateVersionDetails(repo, branch) {
+  const versionsFileUrl = `https://${repo.source}/${repo.owner}/${repo.name}/raw/${branch}/${versionsFileName}`;
+  const versionsFileDist = path.join(distDir, versionsFileName);
+  return {
+    url: versionsFileUrl,
+    dist: versionsFileDist,
+  };
+}

--- a/.openapidoc/package-lock.json
+++ b/.openapidoc/package-lock.json
@@ -5,27 +5,27 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
-      "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.10.1"
+        "@babel/highlight": "^7.10.4"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
-      "integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
-      "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+      "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.10.1",
+        "@babel/helper-validator-identifier": "^7.10.4",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -43,6 +43,24 @@
         }
       }
     },
+    "@eslint/eslintrc": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.1.3.tgz",
+      "integrity": "sha512-4YVwPkANLeNtRjMekzux1ci8hIaH5eGKktGqR0d3LWsKNn5B2X/1Z6Trxy7jQXl9EBGE6Yj02O+t09FMeRllaA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.1.1",
+        "espree": "^7.3.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^3.13.1",
+        "lodash": "^4.17.19",
+        "minimatch": "^3.0.4",
+        "strip-json-comments": "^3.1.1"
+      }
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -50,21 +68,21 @@
       "dev": true
     },
     "acorn": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
-      "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
+      "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
       "dev": true
     },
     "acorn-jsx": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
-      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
       "dev": true
     },
     "ajv": {
-      "version": "6.12.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
-      "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+      "version": "6.12.5",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+      "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -73,22 +91,11 @@
         "uri-js": "^4.2.2"
       }
     },
-    "ansi-escapes": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-      "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
-      "dev": true,
-      "requires": {
-        "type-fest": "^0.11.0"
-      },
-      "dependencies": {
-        "type-fest": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
-          "dev": true
-        }
-      }
+    "ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true
     },
     "ansi-regex": {
       "version": "5.0.0",
@@ -202,36 +209,15 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
         }
       }
-    },
-    "chardet": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-      "dev": true
-    },
-    "cli-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "dev": true,
-      "requires": {
-        "restore-cursor": "^3.1.0"
-      }
-    },
-    "cli-width": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
-      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
-      "dev": true
     },
     "color-convert": {
       "version": "1.9.3",
@@ -252,6 +238,11 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -299,10 +290,19 @@
       "integrity": "sha512-k0/r7GrWVL32kZlGwfPNgB2Y/mMXVTq/decgLczm/j34whdaspNrZO8CnXPf1laaHxI6ptUlsnAxN+UAPw+fzg=="
     },
     "emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
+    },
+    "enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^4.1.1"
+      }
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -310,21 +310,23 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.2.0.tgz",
-      "integrity": "sha512-B3BtEyaDKC5MlfDa2Ha8/D6DsS4fju95zs0hjS3HdGazw+LNayai38A25qMppK37wWGWNYSPOR6oYzlz5MHsRQ==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.9.0.tgz",
+      "integrity": "sha512-V6QyhX21+uXp4T+3nrNfI3hQNBDa/P8ga7LoQOenwrlEFXrEnUEE+ok1dMtaS3b6rmLXhT1TkTIsG75HMLbknA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
+        "@eslint/eslintrc": "^0.1.3",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
+        "enquirer": "^2.3.5",
         "eslint-scope": "^5.1.0",
-        "eslint-utils": "^2.0.0",
-        "eslint-visitor-keys": "^1.2.0",
-        "espree": "^7.1.0",
+        "eslint-utils": "^2.1.0",
+        "eslint-visitor-keys": "^1.3.0",
+        "espree": "^7.3.0",
         "esquery": "^1.2.0",
         "esutils": "^2.0.2",
         "file-entry-cache": "^5.0.1",
@@ -334,12 +336,11 @@
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
-        "inquirer": "^7.0.0",
         "is-glob": "^4.0.0",
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
-        "lodash": "^4.17.14",
+        "lodash": "^4.17.19",
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
@@ -354,39 +355,39 @@
       }
     },
     "eslint-scope": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
-      "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "requires": {
-        "esrecurse": "^4.1.0",
+        "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
       }
     },
     "eslint-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
-      "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
       "dev": true,
       "requires": {
         "eslint-visitor-keys": "^1.1.0"
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.2.0.tgz",
-      "integrity": "sha512-WFb4ihckKil6hu3Dp798xdzSfddwKKU3+nGniKF6HfeW6OLd2OUDEPP7TcHtB5+QXOKg2s6B2DaMPE1Nn/kxKQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
       "dev": true
     },
     "espree": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-7.1.0.tgz",
-      "integrity": "sha512-dcorZSyfmm4WTuTnE5Y7MEN1DyoPYy1ZR783QW1FJoenn7RailyWFsq/UL6ZAAA7uXurN9FIpYyUs3OfiIW+Qw==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.0.tgz",
+      "integrity": "sha512-dksIWsvKCixn1yrEXO8UosNSxaDoSYpq9reEjZSbHLpT5hpaCAKTLBwq0RHtLrIr+c0ByiYzWT8KTMRzoRCNlw==",
       "dev": true,
       "requires": {
-        "acorn": "^7.2.0",
+        "acorn": "^7.4.0",
         "acorn-jsx": "^5.2.0",
-        "eslint-visitor-keys": "^1.2.0"
+        "eslint-visitor-keys": "^1.3.0"
       }
     },
     "esprima": {
@@ -404,20 +405,28 @@
       },
       "dependencies": {
         "estraverse": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.1.0.tgz",
-          "integrity": "sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
           "dev": true
         }
       }
     },
     "esrecurse": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.1.0"
+        "estraverse": "^5.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
+        }
       }
     },
     "estraverse": {
@@ -431,17 +440,6 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
-    },
-    "external-editor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "dev": true,
-      "requires": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
-      }
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -460,15 +458,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
-    },
-    "figures": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-      "dev": true,
-      "requires": {
-        "escape-string-regexp": "^1.0.5"
-      }
     },
     "file-entry-cache": {
       "version": "5.0.1",
@@ -501,6 +490,25 @@
       "requires": {
         "filenamify": "^1.0.0",
         "humanize-url": "^1.0.0"
+      }
+    },
+    "find-cache-dir": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+      "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+      "requires": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      }
+    },
+    "find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "requires": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
       }
     },
     "flat-cache": {
@@ -542,31 +550,32 @@
       "dev": true
     },
     "gh-pages": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-3.0.0.tgz",
-      "integrity": "sha512-oaOfVcrSwnqoWUgZ6cmCDM6mUuWyOSG+SHjqxGBawN0F3SKaF5NwbeYDG+w2RNXO2HJ/5Iam4o7dP5NAtoHuwQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-3.1.0.tgz",
+      "integrity": "sha512-3b1rly9kuf3/dXsT8+ZxP0UhNLOo1CItj+3e31yUVcaph/yDsJ9RzD7JOw5o5zpBTJVQLlJAASNkUfepi9fe2w==",
       "requires": {
         "async": "^2.6.1",
         "commander": "^2.18.0",
         "email-addresses": "^3.0.1",
         "filenamify-url": "^1.0.0",
+        "find-cache-dir": "^3.3.1",
         "fs-extra": "^8.1.0",
         "globby": "^6.1.0"
       }
     },
     "git-up": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/git-up/-/git-up-4.0.1.tgz",
-      "integrity": "sha512-LFTZZrBlrCrGCG07/dm1aCjjpL1z9L3+5aEeI9SBhAqSc+kiA9Or1bgZhQFNppJX6h/f5McrvJt1mQXTFm6Qrw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/git-up/-/git-up-4.0.2.tgz",
+      "integrity": "sha512-kbuvus1dWQB2sSW4cbfTeGpCMd8ge9jx9RKnhXhuJ7tnvT+NIrTVfYZxjtflZddQYcmdOTlkAcjmx7bor+15AQ==",
       "requires": {
         "is-ssh": "^1.3.0",
         "parse-url": "^5.0.0"
       }
     },
     "git-url-parse": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.1.2.tgz",
-      "integrity": "sha512-gZeLVGY8QVKMIkckncX+iCq2/L8PlwncvDFKiWkBn9EtCfYDbliRTTp6qzyQ1VMdITUfq7293zDzfpjdiGASSQ==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.2.0.tgz",
+      "integrity": "sha512-KPoHZg8v+plarZvto4ruIzzJLFQoRx+sUs5DQSr07By9IBKguVd+e6jwrFR6/TP6xrCJlNV1tPqLO1aREc7O2g==",
       "requires": {
         "git-up": "^4.0.0"
       }
@@ -634,15 +643,6 @@
         "strip-url-auth": "^1.0.0"
       }
     },
-    "iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      }
-    },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -679,79 +679,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
-    "inquirer": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.2.0.tgz",
-      "integrity": "sha512-E0c4rPwr9ByePfNlTIB8z51kK1s2n6jrHuJeEHENl/sbq2G/S1auvibgEwNR4uSyiU+PiYHqSwsgGiXjG8p5ZQ==",
-      "dev": true,
-      "requires": {
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^3.0.0",
-        "cli-cursor": "^3.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^3.0.3",
-        "figures": "^3.0.0",
-        "lodash": "^4.17.15",
-        "mute-stream": "0.0.8",
-        "run-async": "^2.4.0",
-        "rxjs": "^6.5.3",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "through": "^2.3.6"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-          "dev": true,
-          "requires": {
-            "@types/color-name": "^1.1.1",
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -759,9 +686,9 @@
       "dev": true
     },
     "is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
     },
     "is-glob": {
@@ -779,9 +706,9 @@
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
     },
     "is-ssh": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.1.tgz",
-      "integrity": "sha512-0eRIASHZt1E68/ixClI8bp2YK2wmBPVWEismTs6M+M099jKgrzl/3E976zIbImSIob48N2/XGe9y7ZiYdImSlg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.2.tgz",
+      "integrity": "sha512-elEw0/0c2UscLrNG+OAorbP539E3rhliKPg+hDMWN9VwrDXfYK+4PBEykDPfxlYYtQvl84TascnQyobfQLHEhQ==",
       "requires": {
         "protocols": "^1.1.0"
       }
@@ -837,16 +764,33 @@
         "type-check": "~0.4.0"
       }
     },
-    "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+    "locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "requires": {
+        "p-locate": "^4.1.0"
+      }
     },
-    "mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true
+    "lodash": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+    },
+    "make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "requires": {
+        "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
+      }
     },
     "minimatch": {
       "version": "3.0.4",
@@ -877,12 +821,6 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
-    "mute-stream": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-      "dev": true
-    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -890,9 +828,9 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "normalize-url": {
       "version": "1.9.1",
@@ -918,15 +856,6 @@
         "wrappy": "1"
       }
     },
-    "onetime": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-      "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
-      "dev": true,
-      "requires": {
-        "mimic-fn": "^2.1.0"
-      }
-    },
     "optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -941,11 +870,26 @@
         "word-wrap": "^1.2.3"
       }
     },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
+    "p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "requires": {
+        "p-limit": "^2.2.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "parent-module": {
       "version": "1.0.1",
@@ -957,18 +901,18 @@
       }
     },
     "parse-path": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.1.tgz",
-      "integrity": "sha512-d7yhga0Oc+PwNXDvQ0Jv1BuWkLVPXcAoQ/WREgd6vNNoKYaW52KI+RdOFjI63wjkmps9yUE8VS4veP+AgpQ/hA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.2.tgz",
+      "integrity": "sha512-HSqVz6iuXSiL8C1ku5Gl1Z5cwDd9Wo0q8CoffdAghP6bz8pJa1tcMC+m4N+z6VAS8QdksnIGq1TB6EgR4vPR6w==",
       "requires": {
         "is-ssh": "^1.3.0",
         "protocols": "^1.4.0"
       }
     },
     "parse-url": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-5.0.1.tgz",
-      "integrity": "sha512-flNUPP27r3vJpROi0/R3/2efgKkyXqnXwyP1KQ2U0SfFRgdizOdWfvrrvJg1LuOoxs7GQhmxJlq23IpQ/BkByg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-5.0.2.tgz",
+      "integrity": "sha512-Czj+GIit4cdWtxo3ISZCvLiUjErSo0iI3wJ+q9Oi3QuMYTI6OZu+7cewMWZ+C1YAnKhYTk6/TLuhIgCypLthPA==",
       "requires": {
         "is-ssh": "^1.3.0",
         "normalize-url": "^3.3.0",
@@ -982,6 +926,11 @@
           "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg=="
         }
       }
+    },
+    "path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -1012,6 +961,14 @@
         "pinkie": "^2.0.0"
       }
     },
+    "pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "requires": {
+        "find-up": "^4.0.0"
+      }
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -1030,9 +987,9 @@
       "dev": true
     },
     "protocols": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.7.tgz",
-      "integrity": "sha512-Fx65lf9/YDn3hUX08XUc0J8rSux36rEsyiv21ZGUC1mOyeM3lTRpZLcrm8aAolzS4itwVfm7TAPyxC2E5zd6xg=="
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.8.tgz",
+      "integrity": "sha512-IgjKyaUSjsROSO8/D49Ab7hP8mJgTYcqApOqdPhLoPxAplXmkp+zRvsrSQjFn5by0rhm4VH0GAUELIPpx7B1yg=="
     },
     "punycode": {
       "version": "2.1.1",
@@ -1061,16 +1018,6 @@
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
     },
-    "restore-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "dev": true,
-      "requires": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      }
-    },
     "rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -1079,27 +1026,6 @@
       "requires": {
         "glob": "^7.1.3"
       }
-    },
-    "run-async": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
-      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
-      "dev": true
-    },
-    "rxjs": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
-      "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
-      "dev": true,
-      "requires": {
-        "tslib": "^1.9.0"
-      }
-    },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
     },
     "semver": {
       "version": "7.3.2",
@@ -1122,12 +1048,6 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
-    "signal-exit": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-      "dev": true
-    },
     "slice-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
@@ -1137,14 +1057,6 @@
         "ansi-styles": "^3.2.0",
         "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        }
       }
     },
     "sort-keys": {
@@ -1166,14 +1078,31 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
     "string-width": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
       "dev": true,
       "requires": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
       }
     },
     "strip-ansi": {
@@ -1186,9 +1115,9 @@
       }
     },
     "strip-json-comments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
-      "integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
     "strip-outer": {
@@ -1223,46 +1152,6 @@
         "lodash": "^4.17.14",
         "slice-ansi": "^2.1.0",
         "string-width": "^3.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        }
       }
     },
     "text-table": {
@@ -1271,21 +1160,6 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
-    "through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
-    },
-    "tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
-      "requires": {
-        "os-tmpdir": "~1.0.2"
-      }
-    },
     "trim-repeated": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
@@ -1293,12 +1167,6 @@
       "requires": {
         "escape-string-regexp": "^1.0.2"
       }
-    },
-    "tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
-      "dev": true
     },
     "type-check": {
       "version": "0.4.0",
@@ -1321,9 +1189,9 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"

--- a/.openapidoc/package.json
+++ b/.openapidoc/package.json
@@ -20,7 +20,7 @@
     "eslint": "^7.2.0"
   },
   "scripts": {
-    "lint": "eslint publish.js",
+    "lint": "eslint publish.js config.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "PegaSys",

--- a/.openapidoc/package.json
+++ b/.openapidoc/package.json
@@ -21,8 +21,9 @@
   },
   "scripts": {
     "lint": "eslint publish.js config.js",
+    "start": "node publish.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "author": "PegaSys",
+  "author": "Consensys Software",
   "license": "Apache-2.0"
 }

--- a/.openapidoc/package.json
+++ b/.openapidoc/package.json
@@ -11,13 +11,13 @@
   },
   "main": "./publish.js",
   "dependencies": {
-    "gh-pages": "^3.0.0",
-    "git-url-parse": "^11.1.2",
+    "gh-pages": "^3.1.0",
+    "git-url-parse": "^11.2.0",
     "js-yaml": "^3.14.0",
-    "node-fetch": "^2.6.0"
+    "node-fetch": "^2.6.1"
   },
   "devDependencies": {
-    "eslint": "^7.2.0"
+    "eslint": "^7.9.0"
   },
   "scripts": {
     "lint": "eslint publish.js config.js",

--- a/.openapidoc/publish.js
+++ b/.openapidoc/publish.js
@@ -11,7 +11,6 @@ const log = (...args) => console.log(...args); // eslint-disable-line no-console
  */
 async function main() {
   const cfg = config.getConfig();
-  log(cfg);
   const { distDir, specs, versions, ghPagesConfig } = cfg;
   try {
     prepareDistDir(distDir);

--- a/.openapidoc/publish.js
+++ b/.openapidoc/publish.js
@@ -1,103 +1,43 @@
 const fs = require("fs");
-const path = require("path");
-const yaml = require("js-yaml");
 const fetch = require("node-fetch");
-const GitUrlParse = require("git-url-parse");
 const ghpages = require("gh-pages");
 
+const config = require("./config.js");
+
 const log = (...args) => console.log(...args); // eslint-disable-line no-console
-
-function getConfig() {
-  const repo = GitUrlParse(
-    process.env.OA_GIT_URL || "git@github.com:PegaSysEng/web3signer.git"
-  );
-  const branch = process.env.OA_GH_PAGES_BRANCH || "gh-pages";
-  const gitUserName = process.env.OA_GIT_USERNAME || "CircleCI Build";
-  const gitUserEmail = process.env.OA_GIT_EMAIL || "ci-build@consensys.net";
-
-  const eth2SpecPath = "../core/build/resources/main/openapi/web3signer-eth2.yaml";
-  const eth1SpecPath = "../core/build/resources/main/openapi/web3signer-eth1.yaml";
-
-  // both spec files have same version
-  const specVersion = yaml.safeLoad(fs.readFileSync(eth2SpecPath, "utf8")).info.version;
-  const isReleaseVersion = !specVersion.includes("-dev-"); // gradle build puts -dev- for snapshot version
-
-  const eth2SpecFileNamePrefix = path.parse(eth2SpecPath).name;
-  const eth2SpecFileNameExtension = path.extname(eth2SpecPath);
-
-  const eth1SpecFileNamePrefix = path.parse(eth1SpecPath).name;
-  const eth1SpecFileNameExtension = path.extname(eth1SpecPath);
-
-  const versionsFileName = process.env.OA_VERSIONS_FILE_NAME || "versions.json";
-  const versionsFileUrl = `https://${repo.source}/${repo.owner}/${repo.name}/raw/${branch}/${versionsFileName}`;
-  const distDir = process.env.OA_DIST_DIR || "./dist";
-  const versionsFileDist = path.join(distDir, versionsFileName);
-  return {
-    eth2Spec: {
-      path: eth2SpecPath,
-      version: specVersion,
-      isReleaseVersion: isReleaseVersion,
-      latestDist: path.join(
-        distDir,
-        `${eth2SpecFileNamePrefix}-latest${eth2SpecFileNameExtension}`
-      ),
-      releaseDist: path.join(
-        distDir,
-        `${eth2SpecFileNamePrefix}-${specVersion}${eth2SpecFileNameExtension}`
-      ),
-    },
-    eth1Spec: {
-      path: eth1SpecPath,
-      version: specVersion,
-      isReleaseVersion: isReleaseVersion,
-      latestDist: path.join(
-        distDir,
-        `${eth1SpecFileNamePrefix}-latest${eth1SpecFileNameExtension}`
-      ),
-      releaseDist: path.join(
-        distDir,
-        `${eth1SpecFileNamePrefix}-${specVersion}${eth1SpecFileNameExtension}`
-      ),
-    },
-    distDir,
-    versions: {
-      url: versionsFileUrl,
-      dist: versionsFileDist,
-    },
-    ghPagesConfig: {
-      add: true, // allows gh-pages module to keep remote files
-      branch: branch,
-      repo: repo.href,
-      user: {
-        name: gitUserName,
-        email: gitUserEmail,
-      },
-      message: `[skip ci] OpenAPI Publish ${specVersion}`,
-    },
-  };
-}
 
 /**
  * Main function to prepare and publish openapi spec to gh-pages branch
  */
 async function main() {
-  const config = getConfig();
-  const { distDir, eth1Spec, eth2Spec, versions, ghPagesConfig } = config;
+  const cfg = config.getConfig();
+  log(cfg);
+  const { distDir, specs, versions, ghPagesConfig } = cfg;
   try {
     prepareDistDir(distDir);
-    copySpecFileToDist(eth2Spec);
-    copySpecFileToDist(eth1Spec);
 
-    if (eth2Spec.isReleaseVersion) {
+    specs.forEach(function (spec) {
+      copySpecFileToDist(spec);
+    });
+
+    if (specs[0].isReleaseVersion) {
       const versionsJson = await fetchVersions(versions.url);
-      const updatedVersionsJson = updateVersions(versionsJson, eth2Spec.version);
+      const updatedVersionsJson = updateVersions(
+        versionsJson,
+        specs[0].version
+      );
       saveVersionsJson(updatedVersionsJson, versions.dist);
     }
+
+    log("Publishing following files: ");
+    fs.readdirSync(distDir).forEach((file) => {
+      log(file);
+    });
 
     cleanGhPagesCache();
     await publishToGHPages(distDir, ghPagesConfig);
     log(
-      `OpenAPI specs [${eth2Spec.version}] published to [${ghPagesConfig.branch}] using user [${ghPagesConfig.user.name}]`
+      `OpenAPI specs [${specs[0].version}] published to [${ghPagesConfig.branch}] using user [${ghPagesConfig.user.name}]`
     );
   } catch (err) {
     log(`ERROR: OpenAPI spec failed to publish: ${err.message}`);

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -82,7 +82,7 @@ artifacts {
 }
 
 processResources {
-  filesMatching('openapi/web3signer.yaml') {
+  filesMatching('openapi/web3signer-*.yaml') {
     filter {
       it.replace('@VERSION@', calculateVersion())
     }

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
@@ -48,6 +48,11 @@ public class Eth1Runner extends Runner {
   }
 
   @Override
+  protected String getOpenApiSpecResource() {
+    return "openapi/web3signer-eth1.yaml";
+  }
+
+  @Override
   protected ArtifactSignerProvider loadSigners(
       final Config config, final Vertx vertx, final MetricsSystem metricsSystem) {
     final AzureKeyVaultSignerFactory azureFactory = new AzureKeyVaultSignerFactory();

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
@@ -56,6 +56,11 @@ public class Eth2Runner extends Runner {
   }
 
   @Override
+  protected String getOpenApiSpecResource() {
+    return "openapi/web3signer-eth2.yaml";
+  }
+
+  @Override
   protected ArtifactSignerProvider loadSigners(
       final Config config, final Vertx vertx, final MetricsSystem metricsSystem) {
     final HashicorpConnectionFactory hashicorpConnectionFactory =

--- a/core/src/main/java/tech/pegasys/web3signer/core/FilecoinRunner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/FilecoinRunner.java
@@ -55,6 +55,11 @@ public class FilecoinRunner extends Runner {
   }
 
   @Override
+  protected String getOpenApiSpecResource() {
+    return "openapi/web3signer-filecoin.yaml";
+  }
+
+  @Override
   public ArtifactSignerProvider loadSigners(
       final Config config, final Vertx vertx, final MetricsSystem metricsSystem) {
     final AzureKeyVaultSignerFactory azureFactory = new AzureKeyVaultSignerFactory();

--- a/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
@@ -67,7 +67,6 @@ public abstract class Runner implements Runnable {
   private static final String CONTENT_TYPE_YAML = "text/x-yaml";
 
   public static final String OPENAPI_INDEX_RESOURCE = "openapi/index.html";
-  public static final String OPENAPI_SPEC_RESOURCE = "openapi/web3signer.yaml";
 
   private static final String SWAGGER_ENDPOINT = "/swagger-ui";
   protected static final String JSON_RPC_PATH = "/rpc/v1";
@@ -101,7 +100,7 @@ public abstract class Runner implements Runnable {
       metricsEndpoint.start(vertx);
 
       final ArtifactSignerProvider signerProvider = loadSigners(config, vertx, metricsSystem);
-      incSignerLoadCount(metricsSystem, signerProvider.availableIdentifiers().stream().count());
+      incSignerLoadCount(metricsSystem, signerProvider.availableIdentifiers().size());
 
       final OpenAPI3RouterFactory routerFactory = getOpenAPI3RouterFactory(vertx);
       registerUpcheckRoute(routerFactory, errorHandler);
@@ -128,12 +127,14 @@ public abstract class Runner implements Runnable {
 
   protected abstract Router populateRouter(final Context context);
 
+  protected abstract String getOpenApiSpecResource();
+
   private OpenAPI3RouterFactory getOpenAPI3RouterFactory(final Vertx vertx)
       throws InterruptedException, ExecutionException {
     final CompletableFuture<OpenAPI3RouterFactory> completableFuture = new CompletableFuture<>();
     OpenAPI3RouterFactory.create(
         vertx,
-        OPENAPI_SPEC_RESOURCE,
+        getOpenApiSpecResource(),
         ar -> {
           if (ar.succeeded()) {
             completableFuture.complete(ar.result());
@@ -173,7 +174,7 @@ public abstract class Runner implements Runnable {
 
   private void registerSwaggerUIRoute(final Router router) throws IOException {
     final URL indexResourceUrl = Resources.getResource(OPENAPI_INDEX_RESOURCE);
-    final URL openApiSpecUrl = Resources.getResource(OPENAPI_SPEC_RESOURCE);
+    final URL openApiSpecUrl = Resources.getResource(getOpenApiSpecResource());
     final String indexHtml = Resources.toString(indexResourceUrl, Charsets.UTF_8);
     final String openApiSpecYaml = Resources.toString(openApiSpecUrl, Charsets.UTF_8);
 

--- a/core/src/main/resources/openapi/web3signer-eth1.yaml
+++ b/core/src/main/resources/openapi/web3signer-eth1.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
-  title: 'Web3Signer'
-  description: 'Sign Eth2 Artifacts'
+  title: 'Web3Signer ETH1 API'
+  description: 'Sign ETH1 Artifacts'
   version: '@VERSION@'
   license:
     name: 'Apache 2.0'
@@ -12,53 +12,6 @@ servers:
   - url: http://localhost:9000/
 
 paths:
-  /api/v1/eth2/sign/{identifier}:
-    post:
-      tags:
-        - 'Signing'
-      summary: 'Signs data for ETH2 BLS public key'
-      description: 'Signs data for the ETH2 BLS public key specified as part of the URL and returns the signature'
-      operationId: 'ETH2_SIGN'
-      parameters:
-        - name: 'identifier'
-          in: 'path'
-          required: true
-          description: 'Key for which data to sign'
-          schema:
-            type: 'string'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                signingRoot:
-                  type: string
-                type:
-                  type: string
-              required:
-                - signingRoot
-              additionalProperties:
-                type: string
-            example:
-              data: 0x48656c6c6f2c20776f726c6421
-
-      responses:
-        '200':
-          description: 'hex encoded string of signature'
-          content:
-            text/plain; charset=utf-8:
-              schema:
-                type: string
-              example: '0xb3baa751d0a9132cfe93e4e3d5ff9075111100e3789dca219ade5a24d27e19d16b3353149da1833e9b691bb38634e8dc04469be7032132906c927d7e1a49b414730612877bc6b2810c8f202daf793d1ab0d6b5cb21d52f9e52e883859887a5d9'
-        '404':
-          description: 'Public Key not found'
-        '400':
-          description: 'Bad request format'
-        '500':
-          description: 'Internal Web3Signer server error'
-
   /api/v1/eth1/sign/{identifier}:
     post:
       tags:
@@ -99,27 +52,6 @@ paths:
               example: '0xb3baa751d0a9132cfe93e4e3d5ff9075111100e3789dca219ade5a24d27e19d16b3353149da1833e9b691bb38634e8dc04469be7032132906c927d7e1a49b414730612877bc6b2810c8f202daf793d1ab0d6b5cb21d52f9e52e883859887a5d9'
         '404':
           description: 'Public Key not found'
-        '400':
-          description: 'Bad request format'
-        '500':
-          description: 'Internal Web3Signer server error'
-
-  /api/v1/eth2/publicKeys:
-    get:
-      tags:
-        - 'Public Key'
-      summary: 'List of available ETH2 BLS Public Keys'
-      description: 'Returns the ETH2 BLS public keys for the private keys that have been loaded into Web3Signer'
-      operationId: 'ETH2_LIST'
-      responses:
-        '200':
-          description: 'list of public keys'
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: string
         '400':
           description: 'Bad request format'
         '500':

--- a/core/src/main/resources/openapi/web3signer-eth2.yaml
+++ b/core/src/main/resources/openapi/web3signer-eth2.yaml
@@ -1,0 +1,103 @@
+openapi: 3.0.0
+info:
+  title: 'Web3Signer ETH2 Api'
+  description: 'Sign Eth2 Artifacts'
+  version: '@VERSION@'
+  license:
+    name: 'Apache 2.0'
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+
+servers:
+  - url: /
+  - url: http://localhost:9000/
+
+paths:
+  /api/v1/eth2/sign/{identifier}:
+    post:
+      tags:
+        - 'Signing'
+      summary: 'Signs data for ETH2 BLS public key'
+      description: 'Signs data for the ETH2 BLS public key specified as part of the URL and returns the signature'
+      operationId: 'ETH2_SIGN'
+      parameters:
+        - name: 'identifier'
+          in: 'path'
+          required: true
+          description: 'Key for which data to sign'
+          schema:
+            type: 'string'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                signingRoot:
+                  type: string
+                type:
+                  type: string
+              required:
+                - signingRoot
+              additionalProperties:
+                type: string
+            example:
+              data: 0x48656c6c6f2c20776f726c6421
+
+      responses:
+        '200':
+          description: 'hex encoded string of signature'
+          content:
+            text/plain; charset=utf-8:
+              schema:
+                type: string
+              example: '0xb3baa751d0a9132cfe93e4e3d5ff9075111100e3789dca219ade5a24d27e19d16b3353149da1833e9b691bb38634e8dc04469be7032132906c927d7e1a49b414730612877bc6b2810c8f202daf793d1ab0d6b5cb21d52f9e52e883859887a5d9'
+        '404':
+          description: 'Public Key not found'
+        '400':
+          description: 'Bad request format'
+        '500':
+          description: 'Internal Web3Signer server error'
+
+  /api/v1/eth2/publicKeys:
+    get:
+      tags:
+        - 'Public Key'
+      summary: 'List of available ETH2 BLS Public Keys'
+      description: 'Returns the ETH2 BLS public keys for the private keys that have been loaded into Web3Signer'
+      operationId: 'ETH2_LIST'
+      responses:
+        '200':
+          description: 'list of public keys'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        '400':
+          description: 'Bad request format'
+        '500':
+          description: 'Internal Web3Signer server error'
+
+  /upcheck:
+    get:
+      tags:
+        - 'Server Status'
+      summary: 'Server Status'
+      description: 'Web3Signer server status'
+      operationId: 'UPCHECK'
+      responses:
+        '200':
+          description: 'OK'
+          content:
+            text/plain; charset=utf-8:
+              schema:
+                type: string
+              example: 'OK'
+        '500':
+          description: 'Internal Web3Signer server error'
+
+externalDocs:
+  description: 'Web3Signer User Documentation'
+  url: 'https://doc.web3signer.pegasys.tech/'

--- a/core/src/main/resources/openapi/web3signer-filecoin.yaml
+++ b/core/src/main/resources/openapi/web3signer-filecoin.yaml
@@ -1,0 +1,35 @@
+openapi: 3.0.0
+info:
+  title: 'Web3Signer Filecoin'
+  description: 'Upcheck'
+  version: '@VERSION@'
+  license:
+    name: 'Apache 2.0'
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+
+servers:
+  - url: /
+  - url: http://localhost:9000/
+
+paths:
+  /upcheck:
+    get:
+      tags:
+        - 'Server Status'
+      summary: 'Server Status'
+      description: 'Web3Signer server status'
+      operationId: 'UPCHECK'
+      responses:
+        '200':
+          description: 'OK'
+          content:
+            text/plain; charset=utf-8:
+              schema:
+                type: string
+              example: 'OK'
+        '500':
+          description: 'Internal Web3Signer server error'
+
+externalDocs:
+  description: 'Web3Signer User Documentation'
+  url: 'https://doc.web3signer.pegasys.tech/'


### PR DESCRIPTION
- Use separate openapi specs for eth1 and eth2 modes. `filecoin` mode openapi spec only uses upcheck method. This results in `OpenApi3RouterFactory` to parse specific spec file and `swagger-ui/web3signer.yaml` to only serve specific spec as well.
- Publish eth1 and eth1 openapi specs to gh-pages branch.