### PR TITLE
Fix transaction contention caused by serializable transaction isolation level

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -112,6 +112,5 @@ dependencyManagement {
 
     dependency 'com.opentable.components:otj-pg-embedded:0.13.3'
     dependency 'org.flywaydb:flyway-core:6.1.1'
-    dependency 'com.h2database:h2:1.4.200'
   }
 }

--- a/slashing-protection/build.gradle
+++ b/slashing-protection/build.gradle
@@ -38,7 +38,6 @@ dependencies {
   testImplementation 'org.jdbi:jdbi3-testing'
   testImplementation 'com.opentable.components:otj-pg-embedded'
   testImplementation 'org.flywaydb:flyway-core'
-  testImplementation 'com.h2database:h2'
 
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
   testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.7.0'

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbConnection.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbConnection.java
@@ -23,6 +23,7 @@ import com.zaxxer.hikari.HikariDataSource;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.argument.Arguments;
 import org.jdbi.v3.core.mapper.ColumnMappers;
+import org.jdbi.v3.core.transaction.SerializableTransactionRunner;
 
 public class DbConnection {
 
@@ -41,6 +42,7 @@ public class DbConnection {
     jdbi.getConfig(ColumnMappers.class)
         .register(new BytesColumnMapper())
         .register(new UInt64ColumnMapper());
+    jdbi.setTransactionHandler(new SerializableTransactionRunner());
   }
 
   private static DataSource createDataSource(
@@ -49,7 +51,6 @@ public class DbConnection {
     dataSource.setJdbcUrl(jdbcUrl);
     dataSource.setUsername(username);
     dataSource.setPassword(password);
-    dataSource.setTransactionIsolation("TRANSACTION_SERIALIZABLE");
     return dataSource;
   }
 }

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtection.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtection.java
@@ -218,7 +218,7 @@ public class DbSlashingProtection implements SlashingProtection {
 
   private void lockForValidator(
       final Handle handle, final LockType lockType, final long validatorId) {
-    final String lockTypePrefix = lockType == LockType.BLOCK ? "0" : "1";
+    final String lockTypePrefix = Integer.toString(lockType.ordinal());
     final String lockId = lockTypePrefix + validatorId;
     handle.execute("SELECT pg_advisory_xact_lock(?)", Long.valueOf(lockId));
   }

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtection.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtection.java
@@ -103,7 +103,7 @@ public class DbSlashingProtection implements SlashingProtection {
       final Bytes signingRoot,
       final UInt64 sourceEpoch,
       final UInt64 targetEpoch,
-      final long validatorId) {
+      final int validatorId) {
     final Optional<SignedAttestation> existingAttestation =
         signedAttestationsDao.findExistingAttestation(h, validatorId, targetEpoch);
     if (existingAttestation.isPresent()) {
@@ -168,7 +168,7 @@ public class DbSlashingProtection implements SlashingProtection {
       final Bytes publicKey,
       final Bytes signingRoot,
       final UInt64 blockSlot,
-      final long validatorId) {
+      final int validatorId) {
     final Optional<SignedBlock> existingBlock =
         signedBlocksDao.findExistingBlock(handle, validatorId, blockSlot);
 

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/dao/SignedAttestation.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/dao/SignedAttestation.java
@@ -17,7 +17,7 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt64;
 
 public class SignedAttestation {
-  private long validatorId;
+  private int validatorId;
   private UInt64 sourceEpoch;
   private UInt64 targetEpoch;
   private Bytes signingRoot;
@@ -26,7 +26,7 @@ public class SignedAttestation {
   public SignedAttestation() {}
 
   public SignedAttestation(
-      final long validatorId,
+      final int validatorId,
       final UInt64 sourceEpoch,
       final UInt64 targetEpoch,
       final Bytes signingRoot) {
@@ -36,11 +36,11 @@ public class SignedAttestation {
     this.signingRoot = signingRoot;
   }
 
-  public long getValidatorId() {
+  public int getValidatorId() {
     return validatorId;
   }
 
-  public void setValidatorId(final long validatorId) {
+  public void setValidatorId(final int validatorId) {
     this.validatorId = validatorId;
   }
 

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/dao/SignedAttestationsDao.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/dao/SignedAttestationsDao.java
@@ -20,7 +20,7 @@ import org.jdbi.v3.core.Handle;
 public class SignedAttestationsDao {
 
   public Optional<SignedAttestation> findExistingAttestation(
-      final Handle handle, final long validatorId, final UInt64 targetEpoch) {
+      final Handle handle, final int validatorId, final UInt64 targetEpoch) {
     return handle
         .createQuery(
             "SELECT validator_id, source_epoch, target_epoch, signing_root "
@@ -33,7 +33,7 @@ public class SignedAttestationsDao {
 
   public Optional<SignedAttestation> findSurroundingAttestation(
       final Handle handle,
-      final long validatorId,
+      final int validatorId,
       final UInt64 sourceEpoch,
       final UInt64 targetEpoch) {
     return handle
@@ -52,7 +52,7 @@ public class SignedAttestationsDao {
 
   public Optional<SignedAttestation> findSurroundedAttestation(
       final Handle handle,
-      final long validatorId,
+      final int validatorId,
       final UInt64 sourceEpoch,
       final UInt64 targetEpoch) {
     return handle

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/dao/SignedBlock.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/dao/SignedBlock.java
@@ -17,24 +17,24 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt64;
 
 public class SignedBlock {
-  private long validatorId;
+  private int validatorId;
   private UInt64 slot;
   private Bytes signingRoot;
 
   // needed for JDBI bean mapping
   public SignedBlock() {}
 
-  public SignedBlock(final long validatorId, final UInt64 slot, final Bytes signingRoot) {
+  public SignedBlock(final int validatorId, final UInt64 slot, final Bytes signingRoot) {
     this.validatorId = validatorId;
     this.slot = slot;
     this.signingRoot = signingRoot;
   }
 
-  public long getValidatorId() {
+  public int getValidatorId() {
     return validatorId;
   }
 
-  public void setValidatorId(final long validatorId) {
+  public void setValidatorId(final int validatorId) {
     this.validatorId = validatorId;
   }
 

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/dao/SignedBlocksDao.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/dao/SignedBlocksDao.java
@@ -20,7 +20,7 @@ import org.jdbi.v3.core.Handle;
 public class SignedBlocksDao {
 
   public Optional<SignedBlock> findExistingBlock(
-      final Handle handle, long validatorId, final UInt64 slot) {
+      final Handle handle, int validatorId, final UInt64 slot) {
     return handle
         .createQuery(
             "SELECT validator_id, slot, signing_root FROM signed_blocks WHERE validator_id = ? AND slot = ?")

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/dao/Validator.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/dao/Validator.java
@@ -15,22 +15,22 @@ package tech.pegasys.web3signer.slashingprotection.dao;
 import org.apache.tuweni.bytes.Bytes;
 
 public class Validator {
-  private long id;
+  private int id;
   private Bytes publicKey;
 
   // needed for JDBI bean mapping
   public Validator() {}
 
-  public Validator(final long id, final Bytes publicKey) {
+  public Validator(final int id, final Bytes publicKey) {
     this.id = id;
     this.publicKey = publicKey;
   }
 
-  public long getId() {
+  public int getId() {
     return id;
   }
 
-  public void setId(final long id) {
+  public void setId(final int id) {
     this.id = id;
   }
 

--- a/slashing-protection/src/main/resources/migrations/postgresql/V1__initial.sql
+++ b/slashing-protection/src/main/resources/migrations/postgresql/V1__initial.sql
@@ -8,7 +8,7 @@ CREATE TABLE signed_blocks (
     slot NUMERIC(20) NOT NULL,
     signing_root BYTEA NOT NULL,
     FOREIGN KEY(validator_id) REFERENCES validators(id),
-    UNIQUE (validator_id, slot, signing_root)
+    UNIQUE (validator_id, slot)
 );
 CREATE TABLE signed_attestations (
     validator_id INTEGER,

--- a/slashing-protection/src/main/resources/migrations/postgresql/V1__initial.sql
+++ b/slashing-protection/src/main/resources/migrations/postgresql/V1__initial.sql
@@ -8,7 +8,7 @@ CREATE TABLE signed_blocks (
     slot NUMERIC(20) NOT NULL,
     signing_root BYTEA NOT NULL,
     FOREIGN KEY(validator_id) REFERENCES validators(id),
-    UNIQUE (validator_id, slot)
+    UNIQUE (validator_id, slot, signing_root)
 );
 CREATE TABLE signed_attestations (
     validator_id INTEGER,

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtectionTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtectionTest.java
@@ -15,7 +15,7 @@ package tech.pegasys.web3signer.slashingprotection;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.never;
@@ -77,7 +77,7 @@ public class DbSlashingProtectionTest {
 
   @Test
   public void blockCanSignWhenNoMatchForPublicKey() {
-    when(signedBlocksDao.findExistingBlock(any(), anyLong(), any())).thenReturn(Optional.empty());
+    when(signedBlocksDao.findExistingBlock(any(), anyInt(), any())).thenReturn(Optional.empty());
 
     assertThat(dbSlashingProtection.maySignBlock(PUBLIC_KEY1, SIGNING_ROOT, SLOT)).isTrue();
     verify(signedBlocksDao).findExistingBlock(any(), eq(VALIDATOR_ID), eq(SLOT));
@@ -88,7 +88,7 @@ public class DbSlashingProtectionTest {
   @Test
   public void blockCanSignWhenExactlyMatchesBlock() {
     final SignedBlock signedBlock = new SignedBlock(VALIDATOR_ID, SLOT, SIGNING_ROOT);
-    when(signedBlocksDao.findExistingBlock(any(), anyLong(), any()))
+    when(signedBlocksDao.findExistingBlock(any(), anyInt(), any()))
         .thenReturn(Optional.of(signedBlock));
 
     assertThat(dbSlashingProtection.maySignBlock(PUBLIC_KEY1, SIGNING_ROOT, SLOT)).isTrue();
@@ -99,7 +99,7 @@ public class DbSlashingProtectionTest {
   @Test
   public void blockCannotSignWhenSamePublicKeyAndSlotButDifferentSigningRoot() {
     final SignedBlock signedBlock = new SignedBlock(VALIDATOR_ID, SLOT, Bytes.of(4));
-    when(signedBlocksDao.findExistingBlock(any(), anyLong(), any()))
+    when(signedBlocksDao.findExistingBlock(any(), anyInt(), any()))
         .thenReturn(Optional.of(signedBlock));
 
     assertThat(dbSlashingProtection.maySignBlock(PUBLIC_KEY1, SIGNING_ROOT, SLOT)).isFalse();
@@ -126,7 +126,7 @@ public class DbSlashingProtectionTest {
   public void attestationCanSignWhenExactlyMatchesExistingAttestation() {
     final SignedAttestation attestation =
         new SignedAttestation(VALIDATOR_ID, SOURCE_EPOCH, TARGET_EPOCH, SIGNING_ROOT);
-    when(signedAttestationsDao.findExistingAttestation(any(), anyLong(), any()))
+    when(signedAttestationsDao.findExistingAttestation(any(), anyInt(), any()))
         .thenReturn(Optional.of(attestation));
 
     assertThat(
@@ -142,12 +142,12 @@ public class DbSlashingProtectionTest {
   public void attestationCannotSignWhenPreviousIsSurroundingAttestation() {
     final SignedAttestation attestation =
         new SignedAttestation(VALIDATOR_ID, SOURCE_EPOCH, TARGET_EPOCH, SIGNING_ROOT);
-    when(signedAttestationsDao.findExistingAttestation(any(), anyLong(), any()))
+    when(signedAttestationsDao.findExistingAttestation(any(), anyInt(), any()))
         .thenReturn(Optional.empty());
     final SignedAttestation surroundingAttestation =
         new SignedAttestation(
             VALIDATOR_ID, SOURCE_EPOCH.subtract(1), TARGET_EPOCH.subtract(1), SIGNING_ROOT);
-    when(signedAttestationsDao.findSurroundingAttestation(any(), anyLong(), any(), any()))
+    when(signedAttestationsDao.findSurroundingAttestation(any(), anyInt(), any(), any()))
         .thenReturn(Optional.of(surroundingAttestation));
 
     assertThat(
@@ -165,13 +165,13 @@ public class DbSlashingProtectionTest {
   public void attestationCannotSignWhenPreviousIsSurroundedByAttestation() {
     final SignedAttestation attestation =
         new SignedAttestation(VALIDATOR_ID, SOURCE_EPOCH, TARGET_EPOCH, SIGNING_ROOT);
-    when(signedAttestationsDao.findExistingAttestation(any(), anyLong(), any()))
+    when(signedAttestationsDao.findExistingAttestation(any(), anyInt(), any()))
         .thenReturn(Optional.empty());
-    when(signedAttestationsDao.findSurroundingAttestation(any(), anyLong(), any(), any()))
+    when(signedAttestationsDao.findSurroundingAttestation(any(), anyInt(), any(), any()))
         .thenReturn(Optional.empty());
     final SignedAttestation surroundedAttestation =
         new SignedAttestation(VALIDATOR_ID, SOURCE_EPOCH.add(1), TARGET_EPOCH.add(1), SIGNING_ROOT);
-    when(signedAttestationsDao.findSurroundedAttestation(any(), anyLong(), any(), any()))
+    when(signedAttestationsDao.findSurroundedAttestation(any(), anyInt(), any(), any()))
         .thenReturn(Optional.of(surroundedAttestation));
 
     assertThat(
@@ -191,11 +191,11 @@ public class DbSlashingProtectionTest {
   public void attestationCanSignWhenNoSurroundingOrSurroundedByAttestation() {
     final SignedAttestation attestation =
         new SignedAttestation(VALIDATOR_ID, SOURCE_EPOCH, TARGET_EPOCH, SIGNING_ROOT);
-    when(signedAttestationsDao.findExistingAttestation(any(), anyLong(), any()))
+    when(signedAttestationsDao.findExistingAttestation(any(), anyInt(), any()))
         .thenReturn(Optional.empty());
-    when(signedAttestationsDao.findSurroundingAttestation(any(), anyLong(), any(), any()))
+    when(signedAttestationsDao.findSurroundingAttestation(any(), anyInt(), any(), any()))
         .thenReturn(Optional.empty());
-    when(signedAttestationsDao.findSurroundedAttestation(any(), anyLong(), any(), any()))
+    when(signedAttestationsDao.findSurroundedAttestation(any(), anyInt(), any(), any()))
         .thenReturn(Optional.empty());
 
     assertThat(
@@ -262,7 +262,7 @@ public class DbSlashingProtectionTest {
 
     assertThat(registeredValidators).hasSize(3);
     assertThat(registeredValidators)
-        .isEqualTo(Map.of(PUBLIC_KEY1, 1L, PUBLIC_KEY2, 2L, PUBLIC_KEY3, 3L));
+        .isEqualTo(Map.of(PUBLIC_KEY1, 1, PUBLIC_KEY2, 2, PUBLIC_KEY3, 3));
     verify(validatorsDao)
         .retrieveValidators(any(), eq(List.of(PUBLIC_KEY1, PUBLIC_KEY2, PUBLIC_KEY3)));
     verify(validatorsDao).registerValidators(any(), eq(List.of(PUBLIC_KEY2, PUBLIC_KEY3)));

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtectionTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtectionTest.java
@@ -48,7 +48,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 @SuppressWarnings("ConstantConditions")
 public class DbSlashingProtectionTest {
-  private static final long VALIDATOR_ID = 1;
+  private static final int VALIDATOR_ID = 1;
   private static final UInt64 SLOT = UInt64.valueOf(2);
   private static final Bytes PUBLIC_KEY1 = Bytes.of(42);
   private static final Bytes PUBLIC_KEY2 = Bytes.of(43);
@@ -244,8 +244,8 @@ public class DbSlashingProtectionTest {
 
   @Test
   public void registersValidatorsThatAreNotAlreadyInDb() {
-    final Map<Bytes, Long> registeredValidators = new HashMap<>();
-    registeredValidators.put(PUBLIC_KEY1, 1L);
+    final Map<Bytes, Integer> registeredValidators = new HashMap<>();
+    registeredValidators.put(PUBLIC_KEY1, 1);
     final DbSlashingProtection dbSlashingProtection =
         new DbSlashingProtection(
             db.getJdbi(),

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtectionTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtectionTest.java
@@ -60,7 +60,7 @@ public class DbSlashingProtectionTest {
   @Mock private ValidatorsDao validatorsDao;
   @Mock private SignedBlocksDao signedBlocksDao;
   @Mock private SignedAttestationsDao signedAttestationsDao;
-  @Rule public JdbiRule db = JdbiRule.h2();
+  @Rule public JdbiRule db = JdbiRule.embeddedPostgres();
 
   private DbSlashingProtection dbSlashingProtection;
 


### PR DESCRIPTION
This fixes an issue where failures were occurring when on updating the slashing protection db.

* Changes the transaction isolation to read committed
* To allow for safe updates a database lock is used against the validator id so that transactions for the same validator id are effectively done serially
* Add transaction retry, needed for the validator registration which still using serializable transaction isolation